### PR TITLE
add host to db credentiials to prevent Peer authentication failure

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,12 +5,14 @@ default: &default
 development:
   <<: *default
   database: <%= LOCAL_DB[:dev_database] %>
+  host: <%= LOCAL_DB[:host] %>
   username: <%= LOCAL_DB[:dev_database_username] %>
   password: <%= LOCAL_DB[:dev_database_password] %>
 
 test:
   <<: *default
   database: <%= LOCAL_DB[:test_database] %>
+  host: <%= LOCAL_DB[:host] %>
   username: <%= LOCAL_DB[:test_database_username] %>
   password: <%= LOCAL_DB[:test_database_password] %>
 


### PR DESCRIPTION
I you don't define host, at least in my computer, it creates am error: 

PG::ConnectionBad: FATAL:  Peer authentication failed for user "postgres"
