### PR TITLE
Add ability to list branches

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -1,0 +1,11 @@
+class RepositoriesController < ApplicationController
+  # TODO : Implement permissions
+  def show
+    repo_url = Repositories::GitRepository.all[params[:id]]
+    @repository = Repositories::GitRepository.new(repo_url, nil)
+  end
+
+  def index
+    render json: Repositories::GitRepository.all.to_json
+  end
+end

--- a/app/models/repositories/git_repository.rb
+++ b/app/models/repositories/git_repository.rb
@@ -1,0 +1,28 @@
+class Repositories::GitRepository < Repository
+  def branches
+    #TODO : Raise exception when authentication fails
+    branches = `git ls-remote -h #{@url}`
+
+    parse_branches(branches)
+  end
+
+  def self.all
+    {
+      '1' => 'git@github.com:ispyropoulos/katanomeas.git',
+      '2' => 'git@github.com:ispyropoulos/katana.git',
+      '3' => 'git@github.com:pakallis/incrediblue.git'
+    }
+  end
+
+  private
+
+  def parse_branches(branches)
+    brs = []
+    branches = branches.split("\n")
+    branches.each do |branch|
+      brs << branch.match(/refs\/heads\/.*/)[0].split("/")[2]
+    end
+
+    brs
+  end
+end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,0 +1,16 @@
+# This is the base class that represents a repository.
+# Subclass this and override its methods for custom behavior.
+# E.g. Repositories::GitRepository
+# A repository is always represented by the url and an authentication
+# token that will be provided in order to grant access to the repository.
+class Repository
+  def initialize(url, access_token)
+    @url = url
+    @access_token = access_token
+  end
+
+  # List all branches in a repository
+  def branches
+    raise "Implement your own adapter for listing branches"
+  end
+end

--- a/app/views/repositories/show.html.haml
+++ b/app/views/repositories/show.html.haml
@@ -1,0 +1,2 @@
+= @repository.branches.each do |branch|
+  = branch

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  resources :test_job_files
+  resources :test_jobs
+  resources :repositories, only: [:show, :index]
   devise_for :users
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".


### PR DESCRIPTION
- List branches for a given repository(Repositories#show)
- List all available repositories(Repositories#index, only 3 repos -
  katana, katanomeas, incrediblue - are provided for the moment)
- Introduce Repository model. By subclassing this model, you can add
  custom behavior for reading a repository
