### PR TITLE
Include database_credentials before running rails

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../boot', __FILE__)
+require File.expand_path('../../config/initializers/database_credentials', __FILE__)
 
 require 'rails/all'
 


### PR DESCRIPTION
Include database_credentials before running rails to prevent
unitialized constant LOCAL_DB exception when starting server
**This breaks on my PC.**
