### PR TITLE
Restrict project creation to owned repos only

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -5,12 +5,14 @@ class ProjectsController < DashboardController
 
   def new
     if client = current_user.github_client
-      @repos = client.repos.
-        reject do |r|
-          r.fork? ||
-            r.id.in?(current_user.projects.pluck(:repository_id)) ||
-            r.full_name =~ /incrediblue/i
-        end.map { |r| Project.new(repository_id: r.id, repository_name: r.name) }
+      owner = client.user
+      @repos = client.repos.reject do |r|
+        r.owner.login != owner.login ||
+          r.id.in?(current_user.projects.pluck(:repository_id))
+      end.map do |r|
+        Project.new(repository_id: r.id, repository_name: r.name,
+          fork: r.fork?)
+      end
     end
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,3 +1,5 @@
 class Project < ActiveRecord::Base
   has_many :tracked_branches, dependent: :destroy
+
+  attr_accessor :fork
 end

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -13,7 +13,7 @@
         %li
           = form_for repo, url: { action: :create } do |f|
             = f.hidden_field :repository_id
-            = f.submit repo.repository_name
+            = "#{f.submit repo.repository_name} #{'(fork)' if repo.fork}".html_safe
 - else
   %h2 Your Testributor account is not connected to GitHub.
   %p


### PR DESCRIPTION
This resolves the problem of attempting webhook creation onto
repos that user is a collaborator (i.e. not the owner).

Creating a project that is based on a repo in which the user is a
collaborating member only would require forking of the repo first.
