### PR TITLE
fix url for oauth app creation in production

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -59,7 +59,7 @@ class ProjectsController < DashboardController
         # Create the projects oauth application
         app = Doorkeeper::Application.new(
           :name => project.repository_id,
-          :redirect_uri => root_url)
+          :redirect_uri => heroku_url)
         app.owner_id = project.id
         app.owner_type = 'Project'
         app.save

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,4 +30,11 @@ module ApplicationHelper
   def github_oauth_authorize_url
     Octokit.authorize_url(Octokit.client_id, scope: 'user:email,repo')
   end
+
+  # we will be using this url for the api in order to avoid buying our
+  # own ssl certificate. Also in order to create an OauthApplication the
+  # redirect_uri must be https. There is a validation for that.
+  def heroku_url
+    'https://testributor.herokuapp.com'
+  end
 end


### PR DESCRIPTION
There is a validation for https when creating OauthApplication.
