### PR TITLE
Add current user when creating a project.

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -27,7 +27,8 @@ class ProjectsController < DashboardController
           name: repo.name,
           repository_provider: 'github',
           repository_id: repo.id,
-          repository_name: repo.name
+          repository_name: repo.name,
+          user: current_user
         )
 
         # Create a Webhook on the same GitHub repo for communicating


### PR DESCRIPTION
This was causing the call to `create` to raise, because
project was invalid, due to the fact that no user existed.
