### PR TITLE
Remove turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'exception_notification'
 # gem 'therubyracer', platforms: :ruby
 
 gem 'jquery-rails'
-gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,8 +283,6 @@ GEM
     tilt (1.4.1)
     timers (4.1.1)
       hitimes
-    turbolinks (2.5.3)
-      coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.1)
@@ -334,7 +332,6 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   sidekiq
   spring
-  turbolinks
   uglifier (>= 1.3.0)
   underscore-rails
   web-console (~> 2.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,6 @@
 //= require jquery
 //= require jquery_ujs
 //= require underscore
-//= require turbolinks
 //= require bootstrap-sprockets
 //= require init
 //= require_tree .

--- a/app/assets/javascripts/run.coffee
+++ b/app/assets/javascripts/run.coffee
@@ -1,10 +1,4 @@
-# Execute js code both on document ready and page:load.
-# 'page:load' is a turbolinks event which is executed
-# when page is changed. Due to the fact that the 'ready' event
-# is not triggered when page is changed,
-# we have to listen to the 'page:load' event as well,
-# so that the following code is executed.
-$(document).on 'ready page:load', ->
+$(document).on 'ready', ->
   $body = $('body')
   module = $body.data('js-class').split('.')
   method = $body.data('js-method')

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,8 +2,8 @@
   %head
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title= brand_name
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true
-    = javascript_include_tag 'application', 'data-turbolinks-track' => true
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
     = csrf_meta_tags
   %body{class: controller_and_action, data: page_data_attrs}
     = render partial: 'layouts/header'


### PR DESCRIPTION
This is causing different issues as the following example:
Visit www.youtube.com and watch a video.
While you watch a video try to use turbolinks within your application.
You will see that your application stops responding, or is too slow.
