### PR TITLE
Add poltergeist and configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ end
 group :test do
   gem "factory_girl_rails"
   gem "capybara"
+  gem 'poltergeist'
   gem 'minitest-rails'
   gem 'minitest-rails-capybara'
   gem 'minitest-spec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
       nenv
       rspec-logsplit (>= 0.1.2)
       timers (>= 4.1.1)
+    cliver (0.3.2)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -222,6 +223,11 @@ GEM
       sawyer (~> 0.6.0, >= 0.5.3)
     orm_adapter (0.5.0)
     pg (0.18.1)
+    poltergeist (1.7.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     puma (2.12.3)
     rack (1.6.4)
     rack-test (0.6.3)
@@ -317,6 +323,9 @@ GEM
     webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+    websocket-driver (0.6.2)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -347,6 +356,7 @@ DEPENDENCIES
   oauth2
   octokit (~> 4.0)
   pg
+  poltergeist
   puma
   rails (= 4.2.3)
   rails_12factor

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,17 @@ require 'rails/test_help'
 require "minitest/rails"
 require "minitest/rails/capybara"
 require "minitest/pride"
+require 'capybara/poltergeist'
+
+# VCR to playback HTTP responses without making actual connections
+require 'vcr'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'test/vcr_cassettes'
+  c.hook_into :webmock
+  c.ignore_localhost = true
+  c.allow_http_connections_when_no_cassette = true
+end
 
 class ActionController::TestCase
   include Devise::TestHelpers
@@ -28,6 +39,7 @@ end
 class Capybara::Rails::TestCase
   include Warden::Test::Helpers
   Warden.test_mode!
+  Capybara.javascript_driver = :poltergeist
 
   def teardown
     Warden.test_reset!


### PR DESCRIPTION
- Add poltergeist for our feature tests.
- Add configuration for Webmock to allow connections to localhost
