### PR TITLE
Fix running time bug when test_job hasn't started

### DIFF
--- a/app/models/test_job.rb
+++ b/app/models/test_job.rb
@@ -24,7 +24,7 @@ class TestJob < ActiveRecord::Base
       time = Time.now - time_first_job_started
     end
 
-    time.round
+    time.round if time
   end
 
   def status_text

--- a/test/models/test_job_test.rb
+++ b/test/models/test_job_test.rb
@@ -26,6 +26,16 @@ class TestJobTest < ActiveSupport::TestCase
 
       job.total_running_time.must_equal 2.hours
     end
+
+    it "returns nil when completed_at, started_at are missing" do
+      times = [
+        { started_at: nil, completed_at: nil },
+      ]
+      create_times(times, job)
+      job.save!
+
+      job.total_running_time.must_equal nil
+    end
   end
 
   private


### PR DESCRIPTION
When a test_job_file with started_at == nil, completed_at == nil
existed, an exception was raised due to nil time variable. Fixed this
issue
