### PR TITLE
Do not require e-mail confirmation to sign-in user

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -155,7 +155,7 @@ Devise.setup do |config|
   # able to access the website for two days without confirming their account,
   # access will be blocked just in the third day. Default is 0.days, meaning
   # the user cannot access the website without confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
+  config.allow_unconfirmed_access_for = 100.years
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm

--- a/test/features/sign_up_feature_test.rb
+++ b/test/features/sign_up_feature_test.rb
@@ -14,9 +14,12 @@ class SignUpFeatureTest < Capybara::Rails::TestCase
       end
 
       it 'asks for e-mail confirmation' do
-        page.current_url.must_equal 'http://www.example.com/'
         ActionMailer::Base.deliveries.select { |m| m.subject.match(/Confirmation/) }.
           wont_be :empty?
+      end
+
+      it "signs in user" do
+        page.must_have_content "Dashboard"
       end
     end
 


### PR DESCRIPTION
This signs in user directly after signup, so that user doesn't have to
open his e-mail and confirm it, then return to site.
