### PR TITLE
Change default project limit for users

### DIFF
--- a/db/migrate/20151019145044_change_projects_limit_default_to_users.rb
+++ b/db/migrate/20151019145044_change_projects_limit_default_to_users.rb
@@ -1,0 +1,5 @@
+class ChangeProjectsLimitDefaultToUsers < ActiveRecord::Migration
+  def change
+    change_column_default :users, :projects_limit, 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150928192621) do
+ActiveRecord::Schema.define(version: 20151019145044) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -143,7 +143,7 @@ ActiveRecord::Schema.define(version: 20150928192621) do
     t.string   "encrypted_github_access_token"
     t.string   "encrypted_github_access_token_salt"
     t.string   "encrypted_github_access_token_iv"
-    t.integer  "projects_limit",                     default: 0,     null: false
+    t.integer  "projects_limit",                     default: 1,     null: false
     t.string   "invitation_token"
     t.datetime "invitation_created_at"
     t.datetime "invitation_accepted_at"


### PR DESCRIPTION
The previous implementation didn't allow users to create projects,
because project limit was 0. Now we default to 1 so that user can create
at least a project.
