### PR TITLE
Clear TestJob attributes when retrying TestJob

### DIFF
--- a/app/controllers/test_jobs_controller.rb
+++ b/app/controllers/test_jobs_controller.rb
@@ -1,18 +1,9 @@
 class TestJobsController < DashboardController
   include Controllers::EnsureProject
 
-  # Here, we use update to retry a failed test job
-  def update
-    @test_job = TestJob.find(params[:id])
-    if @test_job.update(test_job_params)
-      redirect_to :back, notice: 'Test job was successfully updated.'
-    else
-      render :edit
-    end
-  end
-  private
-
-  def test_job_params
-    params.permit(:status)
+  def retry
+    @test_job = TestJob.find(params[:test_job_id])
+    @test_job.retry!
+    redirect_to :back, notice: 'Test job was successfully updated.'
   end
 end

--- a/app/models/test_job.rb
+++ b/app/models/test_job.rb
@@ -54,6 +54,22 @@ class TestJob < ActiveRecord::Base
       self, serializer: InternalTestJobsSerializer).serializable_hash
   end
 
+  def retry!
+    self.result = ''
+    self.status = TestStatus::QUEUED
+    self.completed_at = nil
+    self.test_errors = 0
+    self.failures = 0
+    self.count = 0
+    self.assertions = 0
+    self.skips = 0
+    self.sent_at = nil
+    self.worker_in_queue_seconds = nil
+    self.worker_command_run_seconds = nil
+    self.reported_at = nil
+    save!
+  end
+
   private
 
   def set_completed_at

--- a/app/views/test_runs/show.html.haml
+++ b/app/views/test_runs/show.html.haml
@@ -48,17 +48,12 @@
                       = distance_of_time_in_words(0, test_job.total_running_time, include_seconds: true)
                   %td
                     - if test_job.status.terminal?
-                      - # TODO: tracked branch and test_run nesting seems unecessary
-                      - # for the test_job resource. We only need the project for
-                      - # validation/authorization purposes (to let it work in the
-                      - # same way the rest of the routes work).
-                      = link_to project_branch_test_run_test_job_path(current_project,
-                        test_job.test_run.tracked_branch.id, test_job.test_run.id, test_job,
-                        status: test_job.status.status_to_set),
+                      = link_to project_test_job_retry_path(current_project,
+                        test_job),
                         class: "btn btn-primary btn-xs m-b-5", method: :put do
                         %i.fa.fa-refresh
-                        %span= test_job.status.cta_text
+                        %span= "Retry"
 
                 - if test_job.status.failed? || test_job.status.error?
                   %tr.danger
-                    %td{ colspan: 10, style: "text-align: left" }=simple_format(test_job.result)
+                    %td{ colspan: 10, style: "text-align: left" }= simple_format(test_job.result)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,10 @@ Rails.application.routes.draw do
       get :docker_compose
     end
 
+    resources :test_jobs, only: [] do
+      put :retry
+    end
+
     resources :tracked_branches, only: [:new, :create, :destroy],
       path: :branches, as: :branches do
         resources :test_runs do
@@ -49,7 +53,6 @@ Rails.application.routes.draw do
             post :retry
             post :create
           end
-          resources :test_jobs, only: :update
         end
     end
 


### PR DESCRIPTION
- Introduce TestJobsController#retry so that code is simpler
- Introduce project_test_job_retry_path to reduce the length of the url
  helper
