### PR TITLE
Move paths for TestRunsController actions under Project

### DIFF
--- a/app/serializers/internal_test_jobs_serializer.rb
+++ b/app/serializers/internal_test_jobs_serializer.rb
@@ -38,9 +38,6 @@ class InternalTestJobsSerializer < ActiveModel::Serializer
   end
 
   def retry_url
-    project_branch_test_run_test_job_path(object.test_run.tracked_branch.project,
-                                          object.test_run.tracked_branch_id,
-                                          object.test_run_id, object,
-                                         status: TestStatus::QUEUED)
+    project_test_job_retry_path(object.test_run.project, object)
   end
 end

--- a/app/views/dashboard/_test_run_actions.html.haml
+++ b/app/views/dashboard/_test_run_actions.html.haml
@@ -1,11 +1,11 @@
 - unless test_run.status.code == TestStatus::PASSED
-  = link_to retry_project_branch_test_run_path(id: test_run.id,
-    project_id: current_project, branch_id: test_run.tracked_branch_id),
+  = link_to retry_project_test_run_path(id: test_run.id,
+    project_id: current_project),
     class: 'btn btn-primary btn-xs m-b-5 m-r-5', method: :post do
     %i.fa.fa-refresh
     %span Retry
 - unless test_run.status.code.in? [TestStatus::CANCELLED, TestStatus::PASSED]
-  = link_to project_branch_test_run_path(current_project, test_run.tracked_branch_id,
-    test_run, status: TestStatus::CANCELLED), class: 'btn btn-xs btn-danger m-b-5', method: :put do
+  = link_to project_test_run_path(current_project, test_run,
+    status: TestStatus::CANCELLED), class: 'btn btn-xs btn-danger m-b-5', method: :put do
     .fa.fa-times
     %span Cancel

--- a/app/views/test_runs/index.html.haml
+++ b/app/views/test_runs/index.html.haml
@@ -8,7 +8,7 @@
     .row
       .col-md-12.col-sm-12.col-xs-12
         .pull-right
-          = link_to new_project_branch_test_run_path, method: :post,
+          = link_to project_branch_test_runs_path, method: :post,
             action: :create, class: 'body-gray' do
             %i.fa.fa-plus-circle
             %span= 'Add a new run'
@@ -30,7 +30,7 @@
             - @tracked_branch.test_runs.order("created_at DESC").each do |test_run|
               %tr
                 %td.col-md-1= link_to "##{test_run.id}",
-                  project_branch_test_run_path(current_project, test_run.tracked_branch_id, test_run)
+                  project_test_run_path(current_project, test_run)
                 %td.col-md-5
                   = test_run.decorate.commit_message
                   %br

--- a/app/views/test_runs/show.html.haml
+++ b/app/views/test_runs/show.html.haml
@@ -1,7 +1,8 @@
 - breadcrumb :test_run, current_project, @run
 
 - content_for :page_title do
-  = link_to project_branch_test_runs_path do
+  = link_to project_branch_test_runs_path(current_project,
+    @run.tracked_branch) do
     = "Test Run ##{@run.id}"
 
 .panel.panel-default{ data: { test_run_id: @run.id }}

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -38,7 +38,7 @@ crumb :tracked_branch do |project, branch|
 end
 
 crumb :test_run do |project, run|
-  link "Test Run ##{run.id}", project_branch_test_run_path(project, run.tracked_branch, run)
+  link "Test Run ##{run.id}", project_test_run_path(project, run)
   parent :tracked_branch , project, run.tracked_branch
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,18 +42,19 @@ Rails.application.routes.draw do
       get :docker_compose
     end
 
+    resources :test_runs, only: [:show, :update, :destroy] do
+      member do
+        post :retry
+      end
+    end
+
     resources :test_jobs, only: [] do
       put :retry
     end
 
     resources :tracked_branches, only: [:new, :create, :destroy],
       path: :branches, as: :branches do
-        resources :test_runs do
-          member do
-            post :retry
-            post :create
-          end
-        end
+        resources :test_runs, only: [:index, :create, :new]
     end
 
     resources :project_files, as: :files, path: :files, except: [:edit]

--- a/test/controllers/test_runs_controller_test.rb
+++ b/test/controllers/test_runs_controller_test.rb
@@ -47,8 +47,7 @@ class TestRunsControllerTest < ActionController::TestCase
 
   describe "GET#show" do
     it "returns 200" do
-      get :show,
-        { project_id: project.id, branch_id: branch.id, id: _test_run.id}
+      get :show, { project_id: project.id, id: _test_run.id}
       assert_response :ok
     end
   end

--- a/test/features/test_jobs_index_feature_test.rb
+++ b/test/features/test_jobs_index_feature_test.rb
@@ -40,9 +40,7 @@ class TestJobsIndexFeatureTest < Capybara::Rails::TestCase
     _test_job_cancelled
     _test_job_running
     login_as owner, scope: :user
-    visit project_branch_test_run_path(project,
-                                       _test_run.tracked_branch_id,
-                                       _test_run)
+    visit project_test_run_path(project, _test_run)
   end
 
   it "displays test jobs with correct statuses and ctas", js: true do


### PR DESCRIPTION
- tracked_branch_id is not necessary in some actions under
  TestRunsController. Moved the route helpers for these methods under
  project and removed branch_id
