### PR TITLE
Add rack-attack and basic throttling configuration with logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'exception_notification'
 gem 'gretel'
 gem 'rack-timeout'
 gem 'redcarpet'
+gem 'rack-attack'
 
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,8 @@ GEM
       pry (>= 0.9.10)
     puma (2.12.3)
     rack (1.6.4)
+    rack-attack (4.3.0)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rack-timeout (0.3.2)
@@ -421,6 +423,7 @@ DEPENDENCIES
   pry-nav
   pry-rails
   puma
+  rack-attack
   rack-timeout
   rails (= 4.2.3)
   rails_12factor

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,13 @@ module Katana
     config.active_record.raise_in_transactional_callbacks = true
 
     config.active_job.queue_adapter = :sidekiq
+
+    config.middleware.use Rack::Attack
+    ActiveSupport::Notifications.subscribe('rack.attack') do |name, start, finish, request_id, req|
+      if req.env["rack.attack.match_type"] == :throttle
+        Rails.logger.info "Throttled request from #{req.ip}. Data: " +
+          req.env['rack.attack.throttle_data'].to_s
+      end
+    end
   end
 end

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -1,0 +1,88 @@
+class Rack::Attack
+
+  ### Configure Cache ###
+
+  # If you don't want to use Rails.cache (Rack::Attack's default), then
+  # configure it here.
+  #
+  # Note: The store is only used for throttling (not blacklisting and
+  # whitelisting). It must implement .increment and .write like
+  # ActiveSupport::Cache::Store
+
+  # Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new 
+
+  ### Throttle Spammy Clients ###
+
+  # If any single client IP is making tons of requests, then they're
+  # probably malicious or a poorly-configured scraper. Either way, they
+  # don't deserve to hog all of the app server's CPU. Cut them off!
+  #
+  # Note: If you're serving assets through rack, those requests may be
+  # counted by rack-attack and this throttle may be activated too
+  # quickly. If so, enable the condition to exclude them from tracking.
+
+  # Throttle all requests by IP (60rpm)
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
+  limit = ENV['RACK_ATTACK_LIMIT'] || 150
+  period = (ENV['RACK_ATTACK_PERIOD_SECONDS'] || 60).seconds
+  throttle('req/ip', :limit => limit, :period => period) do |req|
+    req.ip unless req.path.starts_with?('/assets')
+  end
+
+  # Use different limits for api access since workers hit our application in
+  # a more predictable frequency.
+  api_limit = ENV['RACK_ATTACK_API_LIMIT'] || 1
+  api_period = (ENV['RACK_ATTACK_API_PERIOD_SECONDS'] || 1).seconds
+  throttle('api/req/ip', :limit => api_limit, :period => api_period) do |req|
+    req.ip if req.path.starts_with?('/api')
+  end
+
+  ### Prevent Brute-Force Login Attacks ###
+
+  # The most common brute-force login attack is a brute-force password
+  # attack where an attacker simply tries a large number of emails and
+  # passwords to see if any credentials match.
+  #
+  # Another common method of attack is to use a swarm of computers with
+  # different IPs to try brute-forcing a password for a specific account.
+
+  # Throttle POST requests to /login by IP address
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
+  #
+  # throttle('logins/ip', :limit => 5, :period => 20.seconds) do |req|
+  #   if req.path == '/login' && req.post?
+  #     req.ip
+  #   end
+  # end
+
+  # Throttle POST requests to /login by email param
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/email:#{req.email}"
+  #
+  # Note: This creates a problem where a malicious user could intentionally
+  # throttle logins for another user and force their login requests to be
+  # denied, but that's not very common and shouldn't happen to you. (Knock
+  # on wood!)
+  # throttle("logins/email", :limit => 5, :period => 20.seconds) do |req|
+  #   if req.path == '/login' && req.post?
+  #     # return the email if present, nil otherwise
+  #     req.params['email'].presence
+  #   end
+  # end
+
+  ### Custom Throttle Response ###
+
+  # By default, Rack::Attack returns an HTTP 429 for throttled responses,
+  # which is just fine.
+  #
+  # If you want to return 503 so that the attacker might be fooled into
+  # believing that they've successfully broken your app (or you just want to
+  # customize the response), then uncomment these lines.
+  # self.throttled_response = lambda do |env|
+  #  [ 503,  # status
+  #    {},   # headers
+  #    ['']] # body
+  # end
+end


### PR DESCRIPTION
https://trello.com/c/7pbm0hqD/161-add-rack-attack-to-katana-before-we-launch-public-beta

Bash this to see the throttling in action:

```
for i in `seq 1 20`; do curl http://localhost:3000; sleep 0.1;  done
```

The defaults I used are 1 request per second, which is almost equal to 5 workers per ip. This should be enough for now. Normally, if a worker is throttled, the request will be tried again after some seconds so it shouldn't be a problem. (I will try this locally)
