### PR TITLE
[WIP] Use redis to make bind_next_batch atomic

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -50,6 +50,10 @@ class Project < ActiveRecord::Base
     "project_#{id}_workers"
   end
 
+  def test_runs_chunks_redis_key
+    "project_#{id}_test_run_chunks"
+  end
+
   # Updates the project's set of workers with only the active
   # and returns the list of active worker uuids
   # Only this method should be called to find the active workers since directly

--- a/test/controllers/api/v1/test_jobs_controller_test.rb
+++ b/test/controllers/api/v1/test_jobs_controller_test.rb
@@ -3,58 +3,106 @@ require 'test_helper'
 class Api::V1::TestJobsControllerTest < ActionController::TestCase
   let(:project) { FactoryGirl.create(:project) }
   let(:application) { Doorkeeper::Application.new(owner: project) }
-  # ArgumentError: let 'test_run' cannot begin with 'test'. Please use another name.
-  # That's what the _ is for :)
-  let(:_test_run) do
-    FactoryGirl.create(:testributor_run, project: project, status: TestStatus::QUEUED)
-  end
-  let(:_test_jobs) do
-    FactoryGirl.create_list(:testributor_job, 4, test_run: _test_run)
-  end
   let(:token) do
     token = MiniTest::Mock.new
     token.expect(:application, application)
     token.expect(:acceptable?, true, [Doorkeeper::OAuth::Scopes])
   end
 
-  before { _test_jobs }
-
-  describe "PATCH#bind_next_queued" do
-    it "returns queued jobs and updates it's status to RUNNING" do
-      _test_jobs[0..-2].each{|f| f.update_column(:status, TestStatus::RUNNING) }
-      @controller.stub :doorkeeper_token, token do
-        patch :bind_next_batch, default: { format: :json }
+  describe "PATCH#bind_next_batch" do
+    describe "when there is no chunk in Redis queue" do
+      before { Katana::Application.redis.flushall }
+      it "returns and empty test_jobs array" do
+        @controller.stub :doorkeeper_token, token do
+          patch :bind_next_batch, default: { format: :json }
+        end
         result = JSON.parse(response.body)
-        result.first["command"].must_equal _test_jobs[-1].command
-        _test_jobs[-1].reload.status.code.must_equal TestStatus::RUNNING
+        result.count.must_equal 0
       end
     end
 
-    it "does not count incosistent state jobs in workload" do
-      terminal_state_test_run =
-        FactoryGirl.create(:testributor_run, project: project)
+    describe "when the first element in the Redis queue is cancelled" do
+      let(:cancelled_test_run) do
+        FactoryGirl.build(:testributor_run, status: TestStatus::CANCELLED,
+                         project: project)
+      end
+      let(:pending_test_run) do
+        FactoryGirl.build(:testributor_run, status: TestStatus::QUEUED,
+                         project: project)
+      end
 
-      # Incosistent jobs (non terminal state jobs in terminal state run)
-      FactoryGirl.create_list(:testributor_job, 10,
-        test_run: terminal_state_test_run, status: TestStatus::QUEUED)
+      before do
+        10.times {
+          cancelled_test_run.test_jobs.build(
+            command: "ls", status: TestStatus::CANCELLED)
+          pending_test_run.test_jobs.build(
+            command: "ls", status: TestStatus::QUEUED)
+        }
+        Katanomeas.new(cancelled_test_run).assign_chunk_indexes_to_test_jobs
+        Katanomeas.new(pending_test_run).assign_chunk_indexes_to_test_jobs
+        cancelled_test_run.save!
+        pending_test_run.save!
 
-      # Set the TestRun to inconsistent state
-      terminal_state_test_run.update_column(:status, TestStatus::PASSED)
+        assert_equal(
+          Katana::Application.redis.lrange(project.test_runs_chunks_redis_key,-1,-1),
+          ["#{cancelled_test_run.id}_0"])
+      end
 
-      @controller.stub :doorkeeper_token, token do
-        patch :bind_next_batch, default: { format: :json }
+      it "tries the next chunk in queue" do
+        @controller.stub :doorkeeper_token, token do
+          patch :bind_next_batch, default: { format: :json }
+        end
         result = JSON.parse(response.body)
-        result.count.must_equal 4
+        result.count.must_equal 1
+        result.first["id"].must_equal pending_test_run.test_jobs.
+          min{|j| j.chunk_index}.id
       end
     end
 
-    it "returns the cost_prediction for each job" do
-      TestJob.update_all(old_avg_worker_command_run_seconds: 2)
-      @controller.stub :doorkeeper_token, token do
-        patch :bind_next_batch, default: { format: :json }
+    describe "when the first element in the Redis queue is pending" do
+      let(:pending_test_run) do
+        FactoryGirl.build(:testributor_run, status: TestStatus::QUEUED,
+                         project: project)
+      end
+
+      before do
+        10.times {
+          pending_test_run.test_jobs.build(
+            command: "ls", status: TestStatus::QUEUED,
+            old_avg_worker_command_run_seconds: 2)
+        }
+        Katanomeas.new(pending_test_run).assign_chunk_indexes_to_test_jobs
+        pending_test_run.save!
+
+        assert_equal(
+          Katana::Application.redis.lrange(project.test_runs_chunks_redis_key,-1,-1),
+          ["#{pending_test_run.id}_0"])
+      end
+
+      it "returns the test jobs of the retrieved chunk" do
+        @controller.stub :doorkeeper_token, token do
+          patch :bind_next_batch, default: { format: :json }
+        end
         result = JSON.parse(response.body)
-        result.count.must_equal 4
-        result.map{|j| j["cost_prediction"].to_i}.must_equal [2,2,2,2]
+        result.count.must_equal 1
+        result.first["id"].must_equal pending_test_run.test_jobs.
+          min{|j| j.chunk_index}.id
+      end
+
+      it "updates the jobs' status to RUNNING" do
+        @controller.stub :doorkeeper_token, token do
+          patch :bind_next_batch, default: { format: :json }
+        end
+        pending_test_run.test_jobs.map{|j| j.status.code}.uniq.
+          must_equal [TestStatus::QUEUED]
+      end
+
+      it "returns the cost_prediction for each job" do
+        @controller.stub :doorkeeper_token, token do
+          patch :bind_next_batch, default: { format: :json }
+        end
+        result = JSON.parse(response.body)
+        result.map{|j| j["cost_prediction"].to_i}.must_equal [2]
       end
     end
   end

--- a/test/models/test_job_test.rb
+++ b/test/models/test_job_test.rb
@@ -218,7 +218,7 @@ class TestJobTest < ActiveSupport::TestCase
          TestStatus::FAILED, TestStatus::ERROR, TestStatus::CANCELLED].each do |status|
           _test_run.test_jobs.update_all(:status => status)
 
-          _test_run.test_jobs.size.must_equal 2
+          _test_run.test_jobs.count.must_equal 2
           _test_run.update_status!
           _test_run.reload.status.code.must_equal status
         end
@@ -284,7 +284,7 @@ class TestJobTest < ActiveSupport::TestCase
           FactoryGirl.create(:testributor_job, test_run: _test_run, status: status)
         end
 
-        _test_run.test_jobs.size.must_equal 4
+        _test_run.test_jobs.count.must_equal 4
         _test_run.update_status!
         _test_run.reload.status.code.must_equal 5
       end
@@ -296,7 +296,7 @@ class TestJobTest < ActiveSupport::TestCase
           FactoryGirl.create(:testributor_job, test_run: _test_run, status: status)
         end
 
-        _test_run.test_jobs.size.must_equal 4
+        _test_run.test_jobs.count.must_equal 4
         _test_run.update_status!
         _test_run.reload.status.code.must_equal 1
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,7 +22,7 @@ end
 class ActionController::TestCase
   include Devise::TestHelpers
 
-  def setup
+  before do
     # Clean everything in "test" redis database before each test
     Katana::Application.redis.flushdb
     # Stub client_id with a random id so that


### PR DESCRIPTION
The way it was, we had all worker trying to "bind" the first chunk in the queue. This resulted in workers fighting to update the same rows on the database. We put chunks in a redis list so we can make use of the (atomic) POP on redis lists. Each worker gets what's in the queue.

TODO: Every action that puts the test jobs in a pending state should also RPUSH the chunk back into the queue or else the workers won't run it (E.g. when retrying jobs or test runs)
