### PR TITLE
Don't update the timers on TestJobs when they are retried

### DIFF
--- a/app/models/test_job.rb
+++ b/app/models/test_job.rb
@@ -68,16 +68,12 @@ class TestJob < ActiveRecord::Base
   def retry!
     self.result = ''
     self.status = TestStatus::QUEUED
-    self.completed_at = nil
     self.test_errors = 0
     self.failures = 0
     self.count = 0
     self.assertions = 0
     self.skips = 0
-    self.sent_at = nil
-    self.worker_in_queue_seconds = nil
-    self.worker_command_run_seconds = nil
-    self.reported_at = nil
+    self.rerun = true
     save!
   end
 

--- a/app/views/test_runs/show.html.haml
+++ b/app/views/test_runs/show.html.haml
@@ -56,6 +56,10 @@
                         class: "btn btn-primary btn-xs m-b-5", method: :put do
                         %i.fa.fa-refresh
                         %span= "Retry"
+                      - if test_job.rerun?
+                        .btn.btn-xs{ data: { toggle: "tooltip",
+                          title: "This job has been retried. The times shown are those of the first execution" } }
+                          %i.fa.fa-info
 
                 - if test_job.status.unsuccessful?
                   %tr.danger

--- a/db/migrate/20160201141741_add_rerun_attributor_to_jobs.rb
+++ b/db/migrate/20160201141741_add_rerun_attributor_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddRerunAttributorToJobs < ActiveRecord::Migration
+  def change
+    add_column :test_jobs, :rerun, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160131175737) do
+ActiveRecord::Schema.define(version: 20160201141741) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -146,27 +146,28 @@ ActiveRecord::Schema.define(version: 20160131175737) do
 
   create_table "test_jobs", force: :cascade do |t|
     t.integer  "test_run_id"
-    t.string   "command",                                                     default: "", null: false
-    t.text     "result",                                                      default: "", null: false
-    t.integer  "status",                                                      default: 0,  null: false
-    t.integer  "test_errors",                                                 default: 0,  null: false
-    t.integer  "failures",                                                    default: 0,  null: false
-    t.integer  "count",                                                       default: 0,  null: false
-    t.integer  "assertions",                                                  default: 0,  null: false
-    t.integer  "skips",                                                       default: 0,  null: false
+    t.string   "command",                                                     default: "",    null: false
+    t.text     "result",                                                      default: "",    null: false
+    t.integer  "status",                                                      default: 0,     null: false
+    t.integer  "test_errors",                                                 default: 0,     null: false
+    t.integer  "failures",                                                    default: 0,     null: false
+    t.integer  "count",                                                       default: 0,     null: false
+    t.integer  "assertions",                                                  default: 0,     null: false
+    t.integer  "skips",                                                       default: 0,     null: false
     t.datetime "completed_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "before",                                                      default: "", null: false
-    t.text     "after",                                                       default: "", null: false
+    t.text     "before",                                                      default: "",    null: false
+    t.text     "after",                                                       default: "",    null: false
     t.datetime "sent_at"
     t.decimal  "worker_in_queue_seconds",            precision: 10, scale: 6
     t.decimal  "worker_command_run_seconds",         precision: 10, scale: 6
     t.datetime "reported_at"
-    t.integer  "chunk_index",                                                 default: 0,  null: false
+    t.integer  "chunk_index",                                                 default: 0,     null: false
     t.decimal  "avg_worker_command_run_seconds",     precision: 10, scale: 6
     t.decimal  "old_avg_worker_command_run_seconds", precision: 10, scale: 6
     t.string   "job_name"
+    t.boolean  "rerun",                                                       default: false, null: false
   end
 
   create_table "test_runs", force: :cascade do |t|


### PR DESCRIPTION
https://trello.com/c/xlriTGdW/212-when-retrying-a-job-after-a-long-time-the-total-running-time-is-irrelevant
