### PR TITLE
Make project ordering consistent in dashboard index view

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -6,7 +6,8 @@ class DashboardController < ApplicationController
 
   def index
     @projects = current_user.participating_projects.
-      includes(tracked_branches: { test_runs: :test_jobs })
+      includes(tracked_branches: { test_runs: :test_jobs }).
+      order(:repository_owner, :name)
   end
 
   def current_ability

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -232,7 +232,7 @@ class TestRun < ActiveRecord::Base
   end
 
   def last_file_run
-    test_jobs.where('completed_at IS NOT NULL').sort_by(&:completed_at).last
+    test_jobs.reject { |j| j.completed_at.nil? }.sort_by(&:completed_at).last
   end
 
   def github_client


### PR DESCRIPTION
Also, eliminated unnecessary N+1 queries triggered by the
TestRun#last_file_run. It always forced sql queries on the
test_jobs association, even when already loaded.

https://trello.com/c/DdueiFJV/251-project-listed-in-dashboard-view-appear-in-random-order-after-each-refresh
