### PR TITLE
Add webhook endpoint for BitBucket

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,17 +1,27 @@
 class WebhooksController < ApplicationController
-  skip_before_action :verify_authenticity_token, only: :github
+  skip_before_action :verify_authenticity_token, only: [:github, :bitbucket]
   skip_filter :set_redirect_url_in_cookie
-  before_filter :verify_request_from_github!
+  before_filter :verify_request_from_github!, only: :github
 
   def github
     # We listen for 'push' and 'delete' events
     # https://developer.github.com/v3/repos/hooks/#webhook-headers
     if request.headers['HTTP_X_GITHUB_EVENT'] == 'delete' &&
       params[:ref_type] == 'branch'
-      handle_delete
+      handle_github_branch_deletion
     elsif request.headers['HTTP_X_GITHUB_EVENT'] == 'push' &&
       params[:head_commit].present?
-      handle_push
+      handle_github_push
+    end
+
+    head :ok
+  end
+
+  def bitbucket
+    # We listen for 'push' events
+    # https://confluence.atlassian.com/display/bitbucket/event+payloads
+    if request.headers['X-Event-Key'] == 'repo:push'
+      handle_bitbucket_push
     end
 
     head :ok
@@ -19,34 +29,53 @@ class WebhooksController < ApplicationController
 
   private
 
-  def handle_push
+  def handle_github_push
     repository_id = params[:repository][:id]
-    projects = Project.where(repository_provider: 'github',
-      repository_id: repository_id)
-    projects.each do |project|
-      branch_name = params[:ref].split('/').last
-      if (tracked_branch = project.tracked_branches.find_by_branch_name(branch_name))
-        manager = RepositoryManager.new({project: project})
-        head_commit = params[:head_commit]
+    project = Project.where(repository_provider: 'github',
+      repository_id: repository_id).take
+    branch_name = params[:ref].split('/').last
 
-        manager.create_test_run!({
-          commit_sha: head_commit[:id],
-          commit_message: head_commit[:message],
-          commit_timestamp: head_commit[:timestamp],
-          commit_url: head_commit[:url],
-          commit_author_name: head_commit[:author][:name],
-          commit_author_email: head_commit[:author][:email],
-          commit_author_username: head_commit[:author][:username],
-          commit_committer_name: head_commit[:committer][:name],
-          commit_committer_email: head_commit[:committer][:email],
-          commit_committer_username: head_commit[:committer][:username],
-          tracked_branch_id: tracked_branch.id,
-        })
-      end
+    if (tracked_branch = project.tracked_branches.find_by_branch_name(branch_name))
+      manager = RepositoryManager.new({project: project})
+      head_commit = params[:head_commit]
+
+      manager.create_test_run!({
+        commit_sha:                head_commit[:id],
+        commit_message:            head_commit[:message],
+        commit_timestamp:          head_commit[:timestamp],
+        commit_url:                head_commit[:url],
+        commit_author_name:        head_commit[:author][:name],
+        commit_author_email:       head_commit[:author][:email],
+        commit_author_username:    head_commit[:author][:username],
+        commit_committer_name:     head_commit[:committer][:name],
+        commit_committer_email:    head_commit[:committer][:email],
+        commit_committer_username: head_commit[:committer][:username],
+        tracked_branch_id:         tracked_branch.id,
+      })
     end
   end
 
-  def handle_delete
+  def handle_bitbucket_push
+    repository_slug = params[:repository][:name].downcase
+    project = Project.where(repository_provider: 'bitbucket',
+      repository_slug: repository_slug).take
+    branch_name = params[:push][:changes].first[:new][:name]
+
+    if (tracked_branch = project.tracked_branches.find_by_branch_name(branch_name))
+      manager = RepositoryManager.new({project: project})
+      head_commit = params[:push][:changes].first[:new][:target]
+
+      manager.create_test_run!({
+        commit_sha:        head_commit[:hash],
+        commit_message:    head_commit[:message],
+        commit_timestamp:  head_commit[:date],
+        commit_url:        head_commit[:links][:html][:href],
+        tracked_branch_id: tracked_branch.id,
+      })
+    end
+  end
+
+  def handle_github_branch_deletion
     repository_id = params[:repository][:id]
     branch_name = params[:ref]
     # TODO Do any pre-branch removal tasks

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
   get 'oauth/github_callback' => 'oauth#github_callback', as: :github_callback
   get 'oauth/bitbucket_callback' => 'oauth#bitbucket_callback', as: :bitbucket_callback
   post 'webhooks/github' => 'webhooks#github', as: :github_webhook
+  post 'webhooks/bitbucket' => 'webhooks#bitbucket', as: :bitbucket_webhook
 
   authenticated :user do
     root to: "dashboard#index", as: :authenticated_root

--- a/test/factories/project.rb
+++ b/test/factories/project.rb
@@ -1,9 +1,10 @@
 FactoryGirl.define do
   factory :project do
-    sequence(:name) { |n| "ACME #{n}" }
+    sequence(:name) { |n| "ACME_#{n}" }
     association :user
     repository_provider "github"
     sequence(:repository_id) { |n| n }
+    sequence(:repository_name) { |n| "ACME_#{n}" }
 
     after(:create) do |project, evaluator|
       project.docker_image = FactoryGirl.create(:docker_image)


### PR DESCRIPTION
It currently only processes 'push' events and it is also fully
unprotected from attacks. IP whitelisting (the current suggested
BitBucket protection method) will not work on Heroku.
