### PR TITLE
Raise 404 instead of 500 when an invalid wizard step in used in the url.

### DIFF
--- a/app/controllers/project_wizard_controller.rb
+++ b/app/controllers/project_wizard_controller.rb
@@ -3,6 +3,11 @@ class ProjectWizardController < DashboardController
   steps :select_repository, :configure, :add_worker
   before_action :fetch_project
 
+  # https://github.com/schneems/wicked/issues/196
+  rescue_from Wicked::Wizard::InvalidStepError do
+    raise ActionController::RoutingError, "Invalid step"
+  end
+
   def show
     # Inform user that he has reached project limit
     if step == steps.first && !current_user.can_create_new_project?

--- a/test/controllers/project_wizard_controller_test.rb
+++ b/test/controllers/project_wizard_controller_test.rb
@@ -25,6 +25,13 @@ class ProjectWizardControllerTest < ActionController::TestCase
       flash[:alert].must_equal "You need to select a repository first"
       assert_redirected_to project_wizard_path(:select_repository)
     end
+
+    describe "when the requested step does not exist" do
+      it "renders 404 Not Found" do
+        ->{ get :show, id: :some_non_existent_step }.must_raise(
+          ActionController::RoutingError)
+      end
+    end
   end
 
   describe "PUT#update" do


### PR DESCRIPTION
https://github.com/schneems/wicked/issues/196

User might be visiting and old (now changed) link or might type the url
manually. In any case, the right response is 404, not 500.
