### PR TITLE
Add sandbox email interceptor to avoid sending emails from development

### DIFF
--- a/app/models/sandbox_email_interceptor.rb
+++ b/app/models/sandbox_email_interceptor.rb
@@ -1,0 +1,11 @@
+# http://edgeguides.rubyonrails.org/action_mailer_basics.html#intercepting-emails
+class SandboxEmailInterceptor
+  def self.delivering_email(message)
+    address == ENV["MAILINATOR_SANDBOX_ADDRESS"] ||
+      "persona-duckpin-traffic-worker-outguess@mailinator.com"
+
+    message.to = message.to.map do |email|
+      ["#{email} <#{address}>"]
+    end
+  end
+end

--- a/config/initializers/sandbox_email_interceptor.rb
+++ b/config/initializers/sandbox_email_interceptor.rb
@@ -1,0 +1,4 @@
+# http://edgeguides.rubyonrails.org/action_mailer_basics.html#intercepting-emails
+if Rails.env.development?
+  ActionMailer::Base.register_interceptor(SandboxEmailInterceptor)
+end


### PR DESCRIPTION
Although we don't have a setup allowing us to send emails from
development env, we still want to make sure this will never happen.

http://edgeguides.rubyonrails.org/action_mailer_basics.html#intercepting-emails
