### PR TITLE
Properly check if testributor.yml contents are "Hash-able"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,7 +26,7 @@ en:
         project_file:
           attributes:
             contents:
-              no_key_provided: "no 'each:' key or custom command key provided"
+              not_compatible_format: "format not compatible"
               syntax_error: "syntax error"
               each_without_pattern: "'each:' key without 'pattern:' key provided"
               each_without_command: "'each:' key without 'command:' key provided"

--- a/test/models/project_file_test.rb
+++ b/test/models/project_file_test.rb
@@ -38,12 +38,12 @@ class ProjectFileTest < ActiveSupport::TestCase
         file.errors.added?(:contents, :syntax_error).must_equal true
       end
 
-      it "does not allow contents without a key" do
+      it "does not allow contents with an invalid format" do
         contents = "#"
         file = ProjectFile.new(path: file_path, contents: contents)
 
         file.valid?.must_equal false
-        file.errors.added?(:contents, :no_key_provided).must_equal true
+        file.errors.added?(:contents, :not_compatible_format).must_equal true
       end
 
       it "does not allow an 'each' key without a 'pattern'" do
@@ -51,7 +51,6 @@ class ProjectFileTest < ActiveSupport::TestCase
           each:
             command: 'blah'
         YAML
-        contents = ({'each' => { 'command' => 'blah' }}).to_yaml
         file = ProjectFile.new(path: file_path, contents: contents)
 
         file.valid?.must_equal false


### PR DESCRIPTION
Removed previous validation that was catering for the same thing,
but with a misleading error message.
