### PR TITLE
[MIGRATION] Remove "On status change" from initator based notificatio…

### DIFF
--- a/app/models/project_participation.rb
+++ b/app/models/project_participation.rb
@@ -5,6 +5,8 @@ class ProjectParticipation < ActiveRecord::Base
   belongs_to :user
   has_many :branch_notification_settings, dependent: :destroy
 
+  validate :initiator_settings_valid
+
   after_create :create_branch_notification_settings
   after_destroy :remove_invitation_if_any
 
@@ -21,6 +23,17 @@ class ProjectParticipation < ActiveRecord::Base
       self.branch_notification_settings.create!(
         tracked_branch: branch,
         notify_on: self.new_branch_notify_on)
+    end
+  end
+
+  def initiator_settings_valid
+    invalid_setting =
+      BranchNotificationSetting::NOTIFY_ON_MAP.invert[:status_change]
+    if my_builds_notify_on == invalid_setting
+      errors.add(:my_builds_notify_on, :invalid_option)
+    end
+    if others_builds_notify_on == invalid_setting
+      errors.add(:others_builds_notify_on, :invalid_option)
     end
   end
 end

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -169,10 +169,6 @@ class TestRun < ActiveRecord::Base
         end
 
         case BranchNotificationSetting::NOTIFY_ON_MAP[setting]
-        when :status_change
-          if old_status != new_status
-            initiator_based_notifiable_users << participation.user
-          end
         when :always
           initiator_based_notifiable_users << participation.user
         when :every_failure

--- a/app/views/settings/notifications.html.haml
+++ b/app/views/settings/notifications.html.haml
@@ -36,15 +36,18 @@
 
           .col-xs-12
             %h4 Initiator based settings
+            :ruby
+              # On status change does not make sense for initator settings
+              options = BranchNotificationSetting::NOTIFY_ON_MAP_HUMAN.except(
+                BranchNotificationSetting::NOTIFY_ON_MAP.invert[:status_change]).invert
             .col-xs-12.form-row
               = f.input :my_builds_notify_on, as: :select,
-                collection: BranchNotificationSetting::NOTIFY_ON_MAP_HUMAN.invert,
-                include_blank: false, label: "My builds"
+                collection: options, include_blank: false, label: "My builds"
 
             .col-xs-12.form-row
               = f.input :others_builds_notify_on, as: :select,
-                collection: BranchNotificationSetting::NOTIFY_ON_MAP_HUMAN.invert,
-                include_blank: false, label: "Other members builds"
+                collection: options, include_blank: false,
+                label: "Other members builds"
 
           .col-xs-12
             = f.submit "Save", class: 'btn btn-primary'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,12 @@ en:
               project_limit_reached: >
                 You cannot add other projects as you have reached your <strong>project limit</strong>.
                 Please upgrade your plan.
+        project_participation:
+          attributes:
+            my_builds_notify_on:
+              invalid_option: "option not valid"
+            others_builds_notify_on:
+              invalid_option: "option not valid"
         email_submission:
           attributes:
             email:

--- a/db/migrate/20160617102644_change_initiator_settings_defaults.rb
+++ b/db/migrate/20160617102644_change_initiator_settings_defaults.rb
@@ -1,0 +1,14 @@
+class ChangeInitiatorSettingsDefaults < ActiveRecord::Migration
+  def up
+    change_column :projects_users, :my_builds_notify_on, :integer, default: 1, null: false
+    change_column :projects_users, :others_builds_notify_on, :integer, default: 1, null: false
+
+    ProjectParticipation.where(my_builds_notify_on: 0).update_all(my_builds_notify_on: 1)
+    ProjectParticipation.where(others_builds_notify_on: 0).update_all(others_builds_notify_on: 1)
+  end
+
+  def down
+    change_column :projects_users, :my_builds_notify_on, :integer, default: 0, null: false
+    change_column :projects_users, :others_builds_notify_on, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160609113208) do
+ActiveRecord::Schema.define(version: 20160617102644) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -132,8 +132,8 @@ ActiveRecord::Schema.define(version: 20160609113208) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "new_branch_notify_on",    default: 0, null: false
-    t.integer  "my_builds_notify_on",     default: 0, null: false
-    t.integer  "others_builds_notify_on", default: 0, null: false
+    t.integer  "my_builds_notify_on",     default: 1, null: false
+    t.integer  "others_builds_notify_on", default: 1, null: false
   end
 
   add_index "projects_users", ["project_id"], name: "index_projects_users_on_project_id", using: :btree

--- a/test/features/email_notifications_settings_feature_test.rb
+++ b/test/features/email_notifications_settings_feature_test.rb
@@ -42,7 +42,7 @@ class EmailNotificationsSettingsFeatureTest < Capybara::Rails::TestCase
     it "allows the user to change the setting for 'My builds'", js: true do
       participation = owner.project_participations.last
       participation.my_builds_notify_on.must_equal(
-        BranchNotificationSetting::NOTIFY_ON_MAP.invert[:status_change])
+        BranchNotificationSetting::NOTIFY_ON_MAP.invert[:always])
       select "Never", from: "My builds"
       click_on "Save"
       participation.reload.my_builds_notify_on.must_equal(
@@ -57,7 +57,7 @@ class EmailNotificationsSettingsFeatureTest < Capybara::Rails::TestCase
     it "allows the user to change the setting for 'Other member builds'" do
       participation = owner.project_participations.last
       participation.others_builds_notify_on.must_equal(
-        BranchNotificationSetting::NOTIFY_ON_MAP.invert[:status_change])
+        BranchNotificationSetting::NOTIFY_ON_MAP.invert[:always])
       select "Never", from: "Other members builds"
       click_on "Save"
       participation.reload.others_builds_notify_on.must_equal(

--- a/test/models/project_participation_test.rb
+++ b/test/models/project_participation_test.rb
@@ -17,6 +17,32 @@ class ProjectParticipationTest < ActiveSupport::TestCase
     ->{ user_invitation.reload }.must_raise ActiveRecord::RecordNotFound
   end
 
+
+  describe "#initiator_settings_valid" do
+    subject { ProjectParticipation.new }
+    describe "when my_builds_notify_on is :status_changed" do
+      before do
+        subject.my_builds_notify_on =
+          BranchNotificationSetting::NOTIFY_ON_MAP.invert[:status_change]
+      end
+      it "is invalid" do
+        subject.wont_be :valid?
+        subject.errors[:my_builds_notify_on].must_equal ["option not valid"]
+      end
+    end
+
+    describe "when others_builds_notify_on is :status_changed" do
+      before do
+        subject.others_builds_notify_on =
+          BranchNotificationSetting::NOTIFY_ON_MAP.invert[:status_change]
+      end
+      it "is invalid" do
+        subject.wont_be :valid?
+        subject.errors[:others_builds_notify_on].must_equal ["option not valid"]
+      end
+    end
+  end
+
   describe "when a new participation is created" do
     let(:tracked_branches) do
       FactoryGirl.create_list(:tracked_branch, 3, project: project)


### PR DESCRIPTION
…n settings

https://trello.com/c/hguWKX0H/330-katana-seems-to-ignore-the-setting-for-sending-email-notification-only-when-the-status-is-changed
