### PR TITLE
Show failed jobs in email notification

### DIFF
--- a/app/views/test_run_notification_mailer/test_run_complete.html.haml
+++ b/app/views/test_run_notification_mailer/test_run_complete.html.haml
@@ -8,3 +8,32 @@
 completed with status
 = "\"#{@status}\""
 
+- failed_statuses = [TestStatus::FAILED, TestStatus::ERROR]
+- if failed_statuses.include?(@test_run.status.code)
+  %br
+  :ruby
+    jobs_to_show = 2
+    all_jobs =
+      @test_run.test_jobs.select{|j| failed_statuses.include?(j.status.code)}
+
+    if all_jobs.count > jobs_to_show
+      jobs = all_jobs.first(jobs_to_show)
+      limited = true
+    else
+      jobs = all_jobs
+      limited = false
+    end
+
+  #results
+    Below are the failed jobs
+    - if limited
+      %strong
+        = "(only the first #{jobs_to_show} out of a total of #{all_jobs.count} failed)"
+    \:
+
+    - jobs.each do |job|
+      .result{ style: "border: 1px solid #999; border-radius: 5px; margin-top: 20px;" }
+        .job-command{ style: "padding: 10px; font-weight: bold; background-color: #AAA;" }
+          = job.command
+        .job-result{ style: "background-color: #444; padding: 10px; color: #CCC;" }
+          = simple_format(job.result, style: "color: #CCC")

--- a/test/mailers/test_run_notification_mailer_test.rb
+++ b/test/mailers/test_run_notification_mailer_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class TestRunNotificationMailerTest < ActionMailer::TestCase
+  test "test_run_complete" do
+    failed_build = FactoryGirl.create(:testributor_run, :failed)
+    failed_test_job = FactoryGirl.create(:testributor_job,
+                                         test_run: failed_build,
+                                         result: "this is the failure itself",
+                                         status: TestStatus::FAILED)
+    email =
+      TestRunNotificationMailer.test_run_complete(failed_build.id, 'test@example.com')
+ 
+    # Send the email, then test that it got queued
+    assert_emails 1 do
+      email.deliver_now
+    end
+ 
+    # Test the body of the sent email contains what we expect it to
+    email.from.must_equal ['no-reply@testributor.com']
+    email.to.must_equal ['test@example.com']
+    email.subject.must_match(/\[.+\/.+\] Build #\d+ status is now "Failed"/)
+    email.body.to_s.must_match /this is the failure itself/
+  end
+end


### PR DESCRIPTION
https://trello.com/c/3GlMrhmE/302-send-logs-from-failed-jobs
