### PR TITLE
Upgrade to Sidekiq 4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,47 +92,6 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    celluloid (0.17.1.2)
-      bundler
-      celluloid-essentials
-      celluloid-extras
-      celluloid-fsm
-      celluloid-pool
-      celluloid-supervision
-      dotenv
-      nenv
-      rspec-logsplit (>= 0.1.2)
-      timers (>= 4.1.1)
-    celluloid-essentials (0.20.2.1)
-      bundler
-      dotenv
-      nenv
-      rspec-logsplit (>= 0.1.2)
-      timers (>= 4.1.1)
-    celluloid-extras (0.20.1)
-      bundler
-      dotenv
-      nenv
-      rspec-logsplit (>= 0.1.2)
-      timers (>= 4.1.1)
-    celluloid-fsm (0.20.1)
-      bundler
-      dotenv
-      nenv
-      rspec-logsplit (>= 0.1.2)
-      timers (>= 4.1.1)
-    celluloid-pool (0.20.1)
-      bundler
-      dotenv
-      nenv
-      rspec-logsplit (>= 0.1.2)
-      timers (>= 4.1.1)
-    celluloid-supervision (0.20.1.1)
-      bundler
-      dotenv
-      nenv
-      rspec-logsplit (>= 0.1.2)
-      timers (>= 4.1.1)
     cliver (0.3.2)
     coderay (1.1.0)
     coffee-rails (4.1.0)
@@ -158,7 +117,6 @@ GEM
       warden (~> 1.2.3)
     doorkeeper (3.1.0)
       railties (>= 3.2)
-    dotenv (2.0.2)
     draper (2.1.0)
       actionpack (>= 3.0)
       activemodel (>= 3.0)
@@ -211,7 +169,6 @@ GEM
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
     hashie (3.4.4)
-    hitimes (1.2.2)
     html2haml (2.0.0)
       erubis (~> 2.7.0)
       haml (~> 4.0.0)
@@ -268,7 +225,6 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    nenv (0.2.0)
     newrelic_rpm (3.14.0.305)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
@@ -359,13 +315,10 @@ GEM
       rails (>= 3.2)
       tilt
     redcarpet (3.3.3)
-    redis (3.2.1)
-    redis-namespace (1.5.2)
-      redis (~> 3.0, >= 3.0.4)
+    redis (3.3.1)
     request_store (1.2.0)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
-    rspec-logsplit (0.1.3)
     ruby-progressbar (1.7.5)
     ruby_parser (3.7.1)
       sexp_processor (~> 4.1)
@@ -387,12 +340,11 @@ GEM
     select2-rails (4.0.0)
       thor (~> 0.14)
     sexp_processor (4.6.0)
-    sidekiq (3.5.0)
-      celluloid (~> 0.17.0)
+    sidekiq (4.2.0)
+      concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
-      json (~> 1.0)
+      rack-protection (~> 1.5)
       redis (~> 3.2, >= 3.2.1)
-      redis-namespace (~> 1.5, >= 1.5.2)
     simple_form (3.2.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
@@ -418,8 +370,6 @@ GEM
     thread_safe (0.3.5)
     tilt (2.0.5)
     timecop (0.8.0)
-    timers (4.1.1)
-      hitimes
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.1)


### PR DESCRIPTION
This should help with memory bloat and the R14 errors in Heroku.
Sidekiq 4+ has a considerable smaller memory footprint compared
to previous versions.