### PR TITLE
Fix route for Let’s Encrypt identity response

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,5 @@
+class PagesController < ApplicationController
+  def letsencrypt
+    render text: ENV['LETS_ENCRYPT_RESPONSE']
+  end
+end


### PR DESCRIPTION
We need this fix in order to renew the SSL certificate for the www.testributor.com domain.